### PR TITLE
removing border-top for content area

### DIFF
--- a/public/assets/css/ci-theme.css
+++ b/public/assets/css/ci-theme.css
@@ -559,7 +559,6 @@ section#content-outer{
 	margin:0;
 	padding:3px 0;
 	background: #fff;
-	border-top:1px solid #f5f5f5;
 	border-bottom:1px solid #f5f5f5;
 	}
 


### PR DESCRIPTION
since the header part already has a "border-bottom", it duplicates if we apply "border-top" to the content area.