### PR TITLE
Update box-shadow Property

### DIFF
--- a/public/assets/css/ci-theme.css
+++ b/public/assets/css/ci-theme.css
@@ -628,7 +628,7 @@ section.content-outer{
 .ci-features-box:hover {
 	float: left;
 	background: var(--white);
-	box-shadow: 3px 3px 10px #eee;
+	box-shadow: 0px 0px 20px #eee;
 	margin-top: 14px;
 	}
 


### PR DESCRIPTION
I was not happy with the box-shadow property of "ci-features-box" (on our home page) that appears when we hover and finally I've had time to change that. I believe those boxes will seem much better now when we hover on them.