### PR TITLE
fix: GitHub network error handling

### DIFF
--- a/app/Controllers/Contribute.php
+++ b/app/Controllers/Contribute.php
@@ -2,7 +2,7 @@
 
 namespace App\Controllers;
 
-use Github\Exception\ExceptionInterface;
+use Psr\Http\Client\ClientExceptionInterface;
 
 class Contribute extends BaseController
 {
@@ -16,7 +16,9 @@ class Contribute extends BaseController
                 // Contributors are already sorted, so grab the first 12
                 $data['contributors'][$id] = array_slice($contributors, 0, 12);
             }
-        } catch (ExceptionInterface $e) {
+        } catch (ClientExceptionInterface $e) {
+            log_message('error', '[' . __METHOD__ . '] ' . get_class($e) . ': ' . $e->getMessage());
+
             $data['contributors'] = null;
         }
 

--- a/app/Controllers/Download.php
+++ b/app/Controllers/Download.php
@@ -2,7 +2,7 @@
 
 namespace App\Controllers;
 
-use Github\Exception\ExceptionInterface;
+use Psr\Http\Client\ClientExceptionInterface;
 
 class Download extends BaseController
 {
@@ -18,7 +18,9 @@ class Download extends BaseController
                 'v3link' => end($releases['framework3'])->download_url,
                 'v4link' => end($releases['framework4'])->download_url,
             ];
-        } catch (ExceptionInterface $e) {
+        } catch (ClientExceptionInterface $e) {
+            log_message('error', '[' . __METHOD__ . '] ' . get_class($e) . ': ' . $e->getMessage());
+
             $data = [
                 'v3name' => '<em>unknown</em>',
                 'v4name' => '<em>unknown</em>',

--- a/app/Controllers/Home.php
+++ b/app/Controllers/Home.php
@@ -2,7 +2,7 @@
 
 namespace App\Controllers;
 
-use Github\Exception\ExceptionInterface;
+use Psr\Http\Client\ClientExceptionInterface;
 
 class Home extends BaseController
 {
@@ -17,7 +17,9 @@ class Home extends BaseController
                 'stargazers_count' => number_format($repos['codeigniter4']->stargazers_count),
                 'forks_count'      => number_format($repos['codeigniter4']->forks_count),
             ];
-        } catch (ExceptionInterface $e) {
+        } catch (ClientExceptionInterface $e) {
+            log_message('error', '[' . __METHOD__ . '] ' . get_class($e) . ': ' . $e->getMessage());
+
             $data = [
                 'html_url'         => 'https://github.com/codeigniter4/CodeIgniter4',
                 'stargazers_count' => '',

--- a/tests/feature/BasicPagesTest.php
+++ b/tests/feature/BasicPagesTest.php
@@ -4,6 +4,8 @@ use App\Libraries\GitHub;
 use CodeIgniter\Test\DatabaseTestTrait;
 use CodeIgniter\Test\FeatureTestTrait;
 use Config\Services;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Psr7\Request;
 use Tests\Support\ProjectTestCase;
 
 /**
@@ -32,9 +34,9 @@ final class BasicPagesTest extends ProjectTestCase
             ->onlyMethods(['getRepos'])
             ->getMock();
         $github->method('getRepos')->willThrowException(
-            new GuzzleHttp\Exception\ConnectException(
+            new ConnectException(
                 'cURL error 6: Could not resolve host: api.github.com (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for https://api.github.com/repos/bcit-ci/CodeIgniter',
-                new GuzzleHttp\Psr7\Request(
+                new Request(
                     'GET',
                     'https://api.github.com/repos/bcit-ci/CodeIgniter'
                 )

--- a/tests/feature/BasicPagesTest.php
+++ b/tests/feature/BasicPagesTest.php
@@ -1,7 +1,9 @@
 <?php
 
+use App\Libraries\GitHub;
 use CodeIgniter\Test\DatabaseTestTrait;
 use CodeIgniter\Test\FeatureTestTrait;
+use Config\Services;
 use Tests\Support\ProjectTestCase;
 
 /**
@@ -14,6 +16,32 @@ final class BasicPagesTest extends ProjectTestCase
 
     public function testCanViewHome()
     {
+        $result = $this->get('/');
+
+        $result->assertStatus(200);
+        $result->assertSee('The small framework with powerful features');
+    }
+
+    public function testCanViewHomeWhenConnectException()
+    {
+        $github = $this->getMockBuilder(GitHub::class)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->disallowMockingUnknownTypes()
+            ->onlyMethods(['getRepos'])
+            ->getMock();
+        $github->method('getRepos')->willThrowException(
+            new GuzzleHttp\Exception\ConnectException(
+                'cURL error 6: Could not resolve host: api.github.com (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for https://api.github.com/repos/bcit-ci/CodeIgniter',
+                new GuzzleHttp\Psr7\Request(
+                    'GET',
+                    'https://api.github.com/repos/bcit-ci/CodeIgniter'
+                )
+            )
+        );
+        Services::injectMock('github', $github);
+
         $result = $this->get('/');
 
         $result->assertStatus(200);


### PR DESCRIPTION
If GitHub is unreachable, the site returns "Whoops!" and we cannot see the contents.
