### PR TITLE
chore: fix appleboy/ssh-action version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
           ref: master
 
       - name: executing remote ssh commands using ssh key
-        uses: appleboy/ssh-action@v1
+        uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}


### PR DESCRIPTION
Follow-up #441

```
Current runner version: '2.316.1'
Operating System
Runner Image
Runner Image Provisioner
GITHUB_TOKEN Permissions
Secret source: Actions
Prepare workflow directory
Prepare all required actions
Getting action download info
Error: Unable to resolve action `appleboy/ssh-action@v1`, unable to find version `v1`
```
https://github.com/codeigniter4projects/website/actions/runs/9139300340/job/25131430603
